### PR TITLE
fix : fatal error: 'clang/AST/Expr.h' file not found

### DIFF
--- a/clang-fe/INSTALL.md
+++ b/clang-fe/INSTALL.md
@@ -7,6 +7,12 @@ First get the dependencies
 
 On Ubuntu, run `sudo apt-get install llvm-7 libllvm7 clang-7`
 
+## Missing Clang `Headers` :
+
+```bash 
+sudo apt-get install libclang-7-dev
+```
+
 Get them at http://clang.llvm.org/get_started.html
 
 Then run `make` while inside the clang-fe directory. This should make an executable named ssa-transform.


### PR DESCRIPTION
- `make` command fails even after pointing to the correct `clang` include path. 
- Depending on the `setup`, one needs to install `libclang-7-dev` package for missing `clang` headers